### PR TITLE
Adding .node on end of require statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const EventEmitter = require('events');
-const audio = require('../build/Release/audio');
+const audio = require('../build/Release/audio.node');
 
 var init = (mic) => {
 


### PR DESCRIPTION
Adding `.node` on the end of this require statement allows this package to work with webpack out of the box.