### PR TITLE
Specify supported OS is windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.1",
   "description": "Get, Set and Watch Speaker/Microphone Volume on Windows",
   "main": "dist/index.js",
+  "os" : [
+      "win32"
+  ],
   "scripts": {
     "test": "npm i && node sample",
     "babel": "npx babel src --out-dir dist"


### PR DESCRIPTION
This way the package can be included as an optional
dependency and won't print as many errors when
attempting to install it on an unsupported OS.